### PR TITLE
allow numeric prior

### DIFF
--- a/R/mash.R
+++ b/R/mash.R
@@ -134,7 +134,9 @@ mash = function(data,
     if(!missing(optmethod)){stop("cannot supply optmethod if fixg is TRUE")}
   } else {
     optmethod = match.arg(optmethod)
-    prior = match.arg(prior)
+    if (!is.numeric(prior)) {
+      prior = match.arg(prior)
+      }
   }
 
   # Get the number of samples (J), the number of mixture components


### PR DESCRIPTION
It appears that while the `set_prior` function can handle a user-supplied numeric vector prior, `mashr` throws an error unless prior is equal to "nullbiased" or "uniform"

In the [ashR package](https://github.com/stephens999/ashr/blob/master/R/ash.R), this is handled by running `match.arg(prior)` only in the case that prior is not numeric.

The sole change in this PR is amending mashr to match ashr in this way, e.g. wrapping `match.arg(prior)`  in an if statement checking that prior is not numeric.

(First PR, apologies for any misformatting or broken etiquette rules)
